### PR TITLE
remove all handlers by event

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,19 @@ emitter.off('hello', handler)
 emitter.off(globalHandler)
 ```
 
-Remove all event handlers
+Remove all handlers for a given event
+
+```ts
+const handler1 = (value) => console.log(value)
+const handler2 = (value) => console.log(value)
+
+emitter.on('hello', handler1)
+emitter.on('hello', handler2)
+
+emitter.off('hello')
+```
+
+Remove all handlers for all events
 
 ```ts
 emitter.clear()

--- a/docs/additional-details.md
+++ b/docs/additional-details.md
@@ -75,7 +75,19 @@ emitter.off('hello', handler)
 emitter.off(globalHandler)
 ```
 
-### Remove all event handlers
+### Remove all handlers for a given event
+
+```ts
+const handler1 = (value) => console.log(value)
+const handler2 = (value) => console.log(value)
+
+emitter.on('hello', handler1)
+emitter.on('hello', handler2)
+
+emitter.off('hello')
+```
+
+### Remove all handlers for all events
 
 ```ts
 emitter.clear()

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,12 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { createEmitter } from './main'
 
-async function timeout(delay: number = 0): Promise<void> {
-  return new Promise<void>(resolve => {
-    setTimeout(() => resolve(), delay)
-  })
-}
-
 test('calls the handler when an event is emitted', () => {
   const handler = vi.fn()
   const emitter = createEmitter<{ hello: void }>()

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -144,17 +144,27 @@ describe('when clear is called', () => {
 
 describe('when using useBroadcastChannel', () => {
   test('event handler is called on multiple emitters', async () => {
+    const broadcastChannel = 'my-channel'
+    const channel = new BroadcastChannel(broadcastChannel)
     const handlerA = vi.fn()
     const handlerB = vi.fn()
-    const emitterA = createEmitter<{ hello: void }>({ broadcastChannel: 'my-channel' })
-    const emitterB = createEmitter<{ hello: void }>({ broadcastChannel: 'my-channel' })
+    const emitterA = createEmitter<{ hello: void }>({ broadcastChannel })
+    const emitterB = createEmitter<{ hello: void }>({ broadcastChannel })
 
     emitterA.on('hello', handlerA)
     emitterB.on('hello', handlerB)
 
+    const channelReceivedMessage = new Promise<void>(resolve => {
+      channel.addEventListener('message', (message) => {
+        if(message.data.event === 'hello'){
+          setTimeout(() => resolve())
+        }
+      })
+    })
+    
     emitterA.emit('hello')
-
-    await timeout()
+    
+    await channelReceivedMessage
 
     expect(handlerB).toHaveBeenCalledOnce()
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,8 +106,10 @@ export function createEmitter<T extends Events>({ broadcastChannel: useBroadcast
 
     if (handler) {
       eventHandlers?.delete(handler)
-    } else {
-      eventHandlers?.clear()
+      return
+    }
+    
+    eventHandlers?.clear()
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,6 +93,7 @@ export function createEmitter<T extends Events>({ broadcastChannel: useBroadcast
   }
 
   function off(globalEventHandler: GlobalEventHandler): void
+  function off<E extends Event>(event: E): void
   function off<E extends Event>(event: E, handler: Handler<EventPayload<E>>): void
   function off<E extends Event>(globalHandlerOrEvent: E, handler?: Handler<EventPayload<E>>): void {
     if (isGlobalEventHandler(globalHandlerOrEvent)) {
@@ -101,12 +102,13 @@ export function createEmitter<T extends Events>({ broadcastChannel: useBroadcast
     }
 
     const event = globalHandlerOrEvent
+    const eventHandlers = handlers.get(event)
 
-    if (!handler) {
-      throw new Error(`Handler must be given for ${String(event)} event`)
+    if (handler) {
+      eventHandlers?.delete(handler)
+    } else {
+      eventHandlers?.clear()
     }
-
-    handlers.get(globalHandlerOrEvent)?.delete(handler)
   }
 
   function emit<E extends Event>(event: undefined extends EventPayload<E> ? E : never): void

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,7 +110,6 @@ export function createEmitter<T extends Events>({ broadcastChannel: useBroadcast
     }
     
     eventHandlers?.clear()
-    }
   }
 
   function emit<E extends Event>(event: undefined extends EventPayload<E> ? E : never): void


### PR DESCRIPTION
adds syntax to `off` that takes just event name, removes all handlers for the event
- updates docs accordingly
- adds new unit test to prove it
- added logical nesting of tests
- attempted to resolve flakey test for broadcast channel (didn't work but still feels better IMO)

<img width="390" alt="image" src="https://github.com/kitbagjs/events/assets/6098901/d010f9b5-6d43-4b69-a21a-504d7e8e9684">
