### PR TITLE
New "next" method that returns a promise that resolves when the event is emitted

### DIFF
--- a/docs/additional-details.md
+++ b/docs/additional-details.md
@@ -54,6 +54,26 @@ Listen for a single event and then automatically remove the handler
 emitter.once(...)
 ```
 
+## Waiting for an event
+
+Wait for an event to be emitted and get the payload using the `next` method. 
+
+```ts
+const payload = await emitter.next() // Wait for any event
+const payload = await emitter.next('hello') // Wait for the hello event
+```
+
+You can also pass an options object to the `next` method to set a timeout.
+
+```ts
+const payload = await emitter.next({ timeout: 1000 }) // Wait for any event with a timeout of 1 second
+const payload = await emitter.next('hello', { timeout: 1000 }) // Wait for the hello event with a timeout of 1 second
+```
+
+:::info
+If the event is not emitted before the timeout, the `next` method will reject with an `EmitterTimeoutError`.
+:::
+
 ## Removing listeners
 
 ### Return Value

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ features:
   - title: Type safety
     details: Type safe events and payload
   - title: Useful API
-    details: Includes on, off, once, emit, and clear
+    details: Includes on, off, once, next, emit, and clear
   - title: Support Global Handlers
     details: Setup handlers that run on all events
 ---

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -229,3 +229,15 @@ test('next with event returns the event payload', async () => {
 
   await expect(event).resolves.toEqual('world')
 })
+
+test('next with timeout rejects if the event is not emitted', async () => {
+  vi.useFakeTimers()
+  const emitter = createEmitter()
+
+  await expect(() => {
+    const payload = emitter.next({ timeout: 100 })
+    vi.advanceTimersByTime(100)
+
+    return payload
+  }).rejects.toThrowError('Timeout waiting for global event after 100ms')
+})

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -206,3 +206,26 @@ test('broadcast channel can be set after emitter is created', async () => {
   expect(handlerA).toHaveBeenCalledOnce()
   expect(handlerB).toHaveBeenCalledOnce()
 })
+
+test('next without event returns the global event payload', async () => {
+  const emitter = createEmitter<{ hello: string }>()
+
+  const event = emitter.next()
+
+  emitter.emit('hello', 'world')
+
+  await expect(event).resolves.toEqual({
+    kind: 'hello',
+    payload: 'world',
+  })
+})
+
+test('next with event returns the event payload', async () => {
+  const emitter = createEmitter<{ hello: string }>()
+
+  const event = emitter.next('hello')
+
+  emitter.emit('hello', 'world')
+
+  await expect(event).resolves.toEqual('world')
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,6 +109,20 @@ export function createEmitter<T extends Events>(options?: EmitterOptions) {
     on(event, callback)
   }
 
+  function next(): Promise<GlobalEvent<T>>
+  function next<E extends Event>(event: E): Promise<EventPayload<E>>
+  function next<E extends Event>(event?: E): Promise<GlobalEvent<T> |EventPayload<E>> {
+    if(event) {
+      return new Promise((resolve) => {
+        once(event, resolve)
+      })
+    }
+
+    return new Promise((resolve) => {
+      once(resolve)
+    })
+  }
+
   function off(globalEventHandler: GlobalEventHandler<T>): void
   function off<E extends Event>(event: E): void
   function off<E extends Event>(event: E, handler: Handler<EventPayload<E>>): void
@@ -159,6 +173,7 @@ export function createEmitter<T extends Events>(options?: EmitterOptions) {
     on,
     off,
     once,
+    next,
     emit,
     clear,
     setOptions,


### PR DESCRIPTION
# Description
A common use case for event based systems is to pause execution of one task until a specific event is emitted. The `once` method has the functionality for getting the next event, but we can easily add a utility that turns that into a promise. Decided to call it "next" though I'm not tied to that name. 

```ts
const payload = await emitter.next() // any event
const payload = await emitter.next('event-name') // specific event
```

There is also an optional `timeout` option that can be passed witch will automatically reject the promise after the timeout has expired if the expected event has not been emitted. 
```ts
const payload = await emitter.next('event-name', { timeout: 100 })
```
