### PR TITLE
Add support for abort signals when calling `on` and `once`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -222,13 +222,11 @@ export function createEmitter<T extends Events>(options?: EmitterOptions) {
       return () => {}
     }
 
-    const existing = handlers.get(event)
-
-    if (existing) {
-      existing.add(handler)
-    } else {
-      handlers.set(event, new Set([handler]))
+    if(!handlers.has(event)){
+      handlers.set(event, new Set())
     }
+    
+    handlers.get(event)?.add(handler)
 
     const offHandler = () => off(event, handler)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,11 +230,11 @@ export function createEmitter<T extends Events>(options?: EmitterOptions) {
       handlers.set(event, new Set([handler]))
     }
 
-    if(signal) {
-      signal.addEventListener('abort', () => off(event, handler))
-    }
+    const offHandler = () => off(event, handler)
 
-    return () => off(event, handler)
+    signal?.addEventListener('abort', offHandler)
+
+    return offHandler
   }
 
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,9 +208,11 @@ export function createEmitter<T extends Events>(options?: EmitterOptions) {
 
     globalHandlers.add(globalEventHandler)
 
-    signal?.addEventListener('abort', () => off(globalEventHandler))
+    const offHandler = () => off(globalEventHandler)
 
-    return () => off(globalEventHandler)
+    signal?.addEventListener('abort', offHandler)
+
+    return offHandler
   }
 
   function addEventHandler<E extends Event>(event: E, handler: Handler<EventPayload<E>>, options?: EmitterOnOptions): () => void {


### PR DESCRIPTION
# Description
When stopping event handlers its often useful to be able to stop multiple listeners at the same time. By adding support for abort signals multiple handlers can be stopped at once without having to call multiple off callbacks. 
```ts
const controller = new AbortController()

emitter.on(globalHandler, { signal: controller.signal })
emitter.on('eventOne', eventOneHandler, { signal: controller.signal })
emitter.on('eventTwo', eventTwoHandler, { signal: controller.signal })

controller.abort()
```

**Note:** I also organized some test coverage and added some missing test cases to unify testing around `on`, `once, and `next`