### PR TITLE
Adds `count` method for counting event handlers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ features:
   - title: Type safety
     details: Type safe events and payload
   - title: Useful API
-    details: Includes on, off, once, next, emit, and clear
+    details: Includes on, off, once, next, emit, count, and clear
   - title: Support Global Handlers
     details: Setup handlers that run on all events
 ---

--- a/src/createEmitter.ts
+++ b/src/createEmitter.ts
@@ -149,6 +149,26 @@ export function createEmitter<TEvents extends EmitterEvents>(options?: EmitterOp
     onEvent(event, payload!)
   }
 
+  type CountOptions = {
+    global?: boolean
+  }
+
+  function count<E extends TEvent>(): number
+  function count<E extends TEvent>(event: E, options?: CountOptions): number
+  function count<E extends TEvent>(event?: E, { global = false }: CountOptions = {}): number {
+    if(event) {
+      const eventHandlers = handlers.get(event)?.size ?? 0
+
+      if(global) {
+        return eventHandlers + globalHandlers.size
+      }
+
+      return eventHandlers
+    }
+
+    return globalHandlers.size
+  }
+
   function clear(): void {
     handlers.clear()
     globalHandlers.clear()
@@ -210,6 +230,7 @@ export function createEmitter<TEvents extends EmitterEvents>(options?: EmitterOp
     next,
     emit,
     clear,
+    count,
     setOptions,
   }
 }

--- a/tests/events.spec-d.ts
+++ b/tests/events.spec-d.ts
@@ -198,3 +198,32 @@ describe('emitter.setOptions', () => {
     expectTypeOf<Source>().toEqualTypeOf<Expected>()
   })
 })
+
+describe('emitter.count', () => {
+  test('has the correct return type', () => {
+    const emitter = createEmitter<Events>()
+    const response = emitter.count()
+
+    type Source = typeof response
+    type Expected = number
+
+    expectTypeOf<Source>().toEqualTypeOf<Expected>()
+  })
+
+  test('accepts only valid event names', () => {
+    const emitter = createEmitter<Events>()
+
+    emitter.count('ping')
+    emitter.count('hello')
+    emitter.count('user')
+
+    // @ts-expect-error - Invalid event name
+    emitter.count('invalid')
+  })
+
+  test('accepts a global option', () => {
+    const emitter = createEmitter<Events>()
+
+    emitter.count('ping', { global: true })
+  })
+})

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -373,3 +373,21 @@ test('next without event returns the global event payload', async () => {
     payload: 'world',
   })
 })
+
+describe('emitter.count', () => {
+  test('returns the correct number of handlers', () => {
+    const emitter = createEmitter<{ hello: void, goodbye: void }>()
+
+    emitter.on('hello', vi.fn())
+    emitter.on('goodbye', vi.fn())
+    emitter.on(vi.fn())
+
+    expect(emitter.count()).toBe(1)
+    expect(emitter.count('hello')).toBe(1)
+    expect(emitter.count('goodbye')).toBe(1)
+    expect(emitter.count('hello', { global: true })).toBe(2)
+    expect(emitter.count('goodbye', { global: true })).toBe(2)
+    expect(emitter.count('hello', { global: false })).toBe(1)
+    expect(emitter.count('goodbye', { global: false })).toBe(1)
+  })
+})


### PR DESCRIPTION
# Description
Adds a new `count` method which returns a `number`. This can be used to count how many handlers are registered for a specific event.

```ts
const emitter = createEmitter()

emitter.on('ping', () => {...})

const count = emitter.count('ping') // 1
```